### PR TITLE
RaiseEvent and RPC options

### DIFF
--- a/Networking/NetworkingManager.cs
+++ b/Networking/NetworkingManager.cs
@@ -15,13 +15,11 @@ namespace UnboundLib
 
         private static RaiseEventOptions raiseEventOptionsAll = new RaiseEventOptions
         {
-            Receivers = ReceiverGroup.All,
-            CachingOption = EventCaching.AddToRoomCache
+            Receivers = ReceiverGroup.All
         };
         private static RaiseEventOptions raiseEventOptionsOthers = new RaiseEventOptions
         {
-            Receivers = ReceiverGroup.Others,
-            CachingOption = EventCaching.AddToRoomCache
+            Receivers = ReceiverGroup.Others
         };
         private static SendOptions sendOptions = new SendOptions
         {
@@ -47,39 +45,37 @@ namespace UnboundLib
 
             events.Add(eventName, handler);
         }
-        public static void RaiseEvent(string eventName, params object[] data)
-        {
+        public static void RaiseEvent(string eventName, RaiseEventOptions options, params object[] data) {
             if (data == null) data = new object[0];
             var allData = new List<object>();
             allData.Add(eventName);
             allData.AddRange(data);
-            PhotonNetwork.RaiseEvent(ModEventCode, allData.ToArray(), raiseEventOptionsAll, sendOptions);
+            PhotonNetwork.RaiseEvent(ModEventCode, allData.ToArray(), options, sendOptions);
+        }
+        public static void RaiseEvent(string eventName, params object[] data)
+        {
+            RaiseEvent(eventName, raiseEventOptionsAll, data);
         }
         public static void RaiseEventOthers(string eventName, params object[] data)
         {
+            RaiseEvent(eventName, raiseEventOptionsOthers, data);
+        }
+        public static void RPC(Type targetType, string methodName, RaiseEventOptions options, params object[] data)
+        {
             if (data == null) data = new object[0];
             var allData = new List<object>();
-            allData.Add(eventName);
+            allData.Add(targetType.AssemblyQualifiedName);
+            allData.Add(methodName);
             allData.AddRange(data);
-            PhotonNetwork.RaiseEvent(ModEventCode, allData.ToArray(), raiseEventOptionsOthers, sendOptions);
+            PhotonNetwork.RaiseEvent(ModEventCode, allData.ToArray(), options, sendOptions);
         }
         public static void RPC(Type targetType, string methodName, params object[] data)
         {
-            if (data == null) data = new object[0];
-            var allData = new List<object>();
-            allData.Add(targetType.AssemblyQualifiedName);
-            allData.Add(methodName);
-            allData.AddRange(data);
-            PhotonNetwork.RaiseEvent(ModEventCode, allData.ToArray(), raiseEventOptionsAll, sendOptions);
+            RPC(targetType, methodName, raiseEventOptionsAll, data);
         }
         public static void RPC_Others(Type targetType, string methodName, params object[] data)
         {
-            if (data == null) data = new object[0];
-            var allData = new List<object>();
-            allData.Add(targetType.AssemblyQualifiedName);
-            allData.Add(methodName);
-            allData.AddRange(data);
-            PhotonNetwork.RaiseEvent(ModEventCode, allData.ToArray(), raiseEventOptionsOthers, sendOptions);
+            RPC(targetType, methodName, raiseEventOptionsOthers, data);
         }
 
         public static void OnEvent(EventData photonEvent)

--- a/UnboundLib.csproj
+++ b/UnboundLib.csproj
@@ -15,10 +15,10 @@
       <HintPath>..\Libs\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_Assembly-CSharp">
-      <HintPath>A:\Program Files\SteamLibrary\steamapps\common\ROUNDS\BepInEx\plugins\Unbound\MMHOOK_Assembly-CSharp.dll</HintPath>
+      <HintPath>..\Libs\MMHOOK_Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Photon3Unity3D">
-      <HintPath>A:\Program Files\SteamLibrary\steamapps\common\ROUNDS\Rounds_Data\Managed\Photon3Unity3D.dll</HintPath>
+      <HintPath>..\Libs\Photon3Unity3D.dll</HintPath>
     </Reference>
     <Reference Include="PhotonRealtime">
       <HintPath>..\Libs\PhotonRealtime.dll</HintPath>
@@ -27,10 +27,10 @@
       <HintPath>..\Libs\PhotonUnityNetworking.dll</HintPath>
     </Reference>
     <Reference Include="PhotonUnityNetworking.Utilities">
-      <HintPath>A:\Program Files\SteamLibrary\steamapps\common\ROUNDS\Rounds_Data\Managed\PhotonUnityNetworking.Utilities.dll</HintPath>
+      <HintPath>..\Libs\PhotonUnityNetworking.Utilities.dll</HintPath>
     </Reference>
     <Reference Include="Unity.TextMeshPro">
-      <HintPath>A:\Program Files\SteamLibrary\steamapps\common\ROUNDS\Rounds_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+      <HintPath>..\Libs\Unity.TextMeshPro.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>..\Libs\UnityEngine.dll</HintPath>
@@ -42,16 +42,16 @@
       <HintPath>..\Libs\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>A:\Program Files\SteamLibrary\steamapps\common\ROUNDS\Rounds_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>..\Libs\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>A:\Program Files\SteamLibrary\steamapps\common\ROUNDS\Rounds_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\Libs\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIElementsModule">
-      <HintPath>A:\Program Files\SteamLibrary\steamapps\common\ROUNDS\Rounds_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
+      <HintPath>..\Libs\UnityEngine.UIElementsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
-      <HintPath>A:\Program Files\SteamLibrary\steamapps\common\ROUNDS\Rounds_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>..\Libs\UnityEngine.UIModule.dll</HintPath>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
- **BREAKING CHANGE**: Changed default caching option to `CachingOption.DoNotCache` for events and RPCs, since it's the default for Photon.
- Added overloads to `RaiseEvent` and `RPC` methods, allowing users to specify their own `RaiseEventOptions`. It was previously not possible to change the receiver (except all or others) or caching options at all.
- Made assembly references relative. I don't know how references should be handled when contributing.